### PR TITLE
cleanup build deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN \
  node node_modules/gulp/bin/gulp.js && \
  npm uninstall gulp && \
  echo "**** cleanup ****" && \
- echo "**** cleanup ****" && \
+ apk del --purge \
+	build-dependencies && \
  rm -rf \
 	/root \
 	/tmp/* && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -42,6 +42,8 @@ RUN \
  node node_modules/gulp/bin/gulp.js && \
  npm uninstall gulp && \
  echo "**** cleanup ****" && \
+ apk del --purge \
+	build-dependencies && \
  rm -rf \
 	/root \
 	/tmp/* && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -42,6 +42,8 @@ RUN \
  node node_modules/gulp/bin/gulp.js && \
  npm uninstall gulp && \
  echo "**** cleanup ****" && \
+ apk del --purge \
+	build-dependencies && \
  rm -rf \
 	/root \
 	/tmp/* && \


### PR DESCRIPTION
Missed this in the go live, it was causing an endless loop of package updating. 